### PR TITLE
Bug Fix: Replace '||' with '|'. '||' matches everythings.

### DIFF
--- a/tpch_hive/q19_discounted_revenue.hive
+++ b/tpch_hive/q19_discounted_revenue.hive
@@ -12,27 +12,27 @@ from
 where
   (
     p_brand = 'Brand#12'
-	and p_container REGEXP 'SM CASE||SM BOX||SM PACK||SM PKG'
+	and p_container REGEXP 'SM CASE|SM BOX|SM PACK|SM PKG'
 	and l_quantity >= 1 and l_quantity <= 11
 	and p_size >= 1 and p_size <= 5
-	and l_shipmode REGEXP 'AIR||AIR REG'
+	and l_shipmode REGEXP 'AIR|AIR REG'
 	and l_shipinstruct = 'DELIVER IN PERSON'
   ) 
   or 
   (
     p_brand = 'Brand#23'
-	and p_container REGEXP 'MED BAG||MED BOX||MED PKG||MED PACK'
+	and p_container REGEXP 'MED BAG|MED BOX|MED PKG|MED PACK'
 	and l_quantity >= 10 and l_quantity <= 20
 	and p_size >= 1 and p_size <= 10
-	and l_shipmode REGEXP 'AIR||AIR REG'
+	and l_shipmode REGEXP 'AIR|AIR REG'
 	and l_shipinstruct = 'DELIVER IN PERSON'
   )
   or
   (
 	p_brand = 'Brand#34'
-	and p_container REGEXP 'LG CASE||LG BOX||LG PACK||LG PKG'
+	and p_container REGEXP 'LG CASE|LG BOX|LG PACK|LG PKG'
 	and l_quantity >= 20 and l_quantity <= 30
 	and p_size >= 1 and p_size <= 15
-	and l_shipmode REGEXP 'AIR||AIR REG'
+	and l_shipmode REGEXP 'AIR|AIR REG'
 	and l_shipinstruct = 'DELIVER IN PERSON'
   )

--- a/tpch_impala/q19_discounted_revenue.impala
+++ b/tpch_impala/q19_discounted_revenue.impala
@@ -9,27 +9,27 @@ from
 where
   (
     p_brand = 'Brand#12'
-	and p_container REGEXP 'SM CASE||SM BOX||SM PACK||SM PKG'
+	and p_container REGEXP 'SM CASE|SM BOX|SM PACK|SM PKG'
 	and l_quantity >= 1 and l_quantity <= 11
 	and p_size >= 1 and p_size <= 5
-	and l_shipmode REGEXP 'AIR||AIR REG'
+	and l_shipmode REGEXP 'AIR|AIR REG'
 	and l_shipinstruct = 'DELIVER IN PERSON'
   ) 
   or 
   (
     p_brand = 'Brand#23'
-	and p_container REGEXP 'MED BAG||MED BOX||MED PKG||MED PACK'
+	and p_container REGEXP 'MED BAG|MED BOX|MED PKG|MED PACK'
 	and l_quantity >= 10 and l_quantity <= 20
 	and p_size >= 1 and p_size <= 10
-	and l_shipmode REGEXP 'AIR||AIR REG'
+	and l_shipmode REGEXP 'AIR|AIR REG'
 	and l_shipinstruct = 'DELIVER IN PERSON'
   )
   or
   (
 	p_brand = 'Brand#34'
-	and p_container REGEXP 'LG CASE||LG BOX||LG PACK||LG PKG'
+	and p_container REGEXP 'LG CASE|LG BOX|LG PACK|LG PKG'
 	and l_quantity >= 20 and l_quantity <= 30
 	and p_size >= 1 and p_size <= 15
-	and l_shipmode REGEXP 'AIR||AIR REG'
+	and l_shipmode REGEXP 'AIR|AIR REG'
 	and l_shipinstruct = 'DELIVER IN PERSON'
   )


### PR DESCRIPTION
Your code is very helpful. By the way, for TPC-H Q19 semantics,  '|' is proper. '||' does not work correctly since it matches everything. 
